### PR TITLE
Persistencia de updates a usuarios

### DIFF
--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -1,6 +1,7 @@
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:geo_stories/models/user_dto.dart';
 
 class UserService {
   static FirebaseAuth auth = FirebaseAuth.instance;
@@ -25,10 +26,40 @@ class UserService {
     await database.collection("users")
         .doc(userID)
         .set({
-          'username': userName,
-          'avatarUrl': ''
+          'username': userName
         });
 
+    await userCredential.user.updateProfile(displayName: userName, photoURL: null);
+    await userCredential.user.reload();
     return userID;
+  }
+
+  static Future<void> updateCurrentUserProfile(UserDTO userUpdate) async {
+    final User user = auth.currentUser;
+    String updateAvatarUrl;
+    String updateUsername;
+
+    if (userUpdate.username != null) {
+      updateUsername = userUpdate.username;
+    } else {
+      updateUsername = user.displayName;
+    }
+
+    if (userUpdate.avatarUrl != null) {
+      updateAvatarUrl = userUpdate.avatarUrl;
+    } else {
+      updateAvatarUrl = user.photoURL;
+    }
+
+    await user.updateProfile(
+      displayName: updateUsername,
+      photoURL: updateAvatarUrl
+    );
+
+    await user.reload();
+  }
+
+  static User getCurrentUser() {
+    return auth.currentUser;
   }
 }


### PR DESCRIPTION
* update usuario desde UserService
* el módulo Firebase Authentication puede guardar userName y avatarUrl del usuario logueado/registrandose, y tiene formas de acceder a ambos.
* removido persistencia de avatarUrl en Firestore por ser redundante. Sin embargo, se mantiene la persistencia de userName para validar (en un futuro cercano) que no se puedan crear usuarios con usernames que ya existan (ya que hacer esto con Firebase Auth es imposible, nomas le podes consultar de 1 usuario a la vez y no tiene formas de implementar validaciones de este estilo).