### PR TITLE
Precachear logo svg de geostories en WelcomePage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,14 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:geo_stories/screens/welcome_page.dart';
 
 Future<void> main() async {
   //debugPaintSizeEnabled = true;
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
+  await precachePicture(ExactAssetPicture(SvgPicture.svgStringDecoder, 'assets/icons/geostories-logo.svg'), null);
   runApp(MyApp());
 }
 


### PR DESCRIPTION
Esto soluciona el problema del logo tardando más en cargar que el resto de la UI al abrir la app. Ocurre porque flutter por defecto no sabe manejar bien los SVGs.