### PR TITLE
Cambios en colores & removido icono del tacho al abrir un marker

### DIFF
--- a/lib/components/main_drawer.dart
+++ b/lib/components/main_drawer.dart
@@ -90,7 +90,7 @@ class _MainDrawerState extends State<MainDrawer> {
                   )
                 ],
               ),
-          decoration: BoxDecoration( color: kColorLightOrange),
+          decoration: BoxDecoration( color: kColorLightblue),
         );
   }
   ListTile _buildLogOut(BuildContext context, bool _enableEdit) {

--- a/lib/components/marker_icon.dart
+++ b/lib/components/marker_icon.dart
@@ -61,13 +61,6 @@ class MarkerIcon extends StatelessWidget {
               onTap: onLikeButtonTapped,
             ),
             IconButton(
-                key: ValueKey("DeleteButton"),
-                icon: Icon(Icons.delete),
-                color: Colors.red,
-                onPressed: () {
-                  //TODO BORRAR EL MARCADOR
-                }),
-            IconButton(
               key: ValueKey("EditButton"),
               icon : Icon(Icons.edit_outlined),
               color: Colors.black,

--- a/lib/screens/edit_marker_page.dart
+++ b/lib/screens/edit_marker_page.dart
@@ -35,8 +35,8 @@ class EditMarkerPage extends State<EditMarker> {
     Size size = MediaQuery.of(context).size;
     return Scaffold(
         appBar: AppBar(
-          title: Text("Editar un nuevo marker "),
-          backgroundColor: kColorLightOrange,
+          title: Text("Editar marcador"),
+          backgroundColor: kColorLightblue,
         ),
         body:Padding(
           padding: const EdgeInsets.all(16.0),

--- a/lib/screens/map_page.dart
+++ b/lib/screens/map_page.dart
@@ -84,7 +84,7 @@ class _MapPageState extends State<MapPage> {
     return Scaffold(
       drawer: MainDrawer(),
       extendBodyBehindAppBar: true,
-      appBar: AppBar(title: Text(_modoHeaderTitle), backgroundColor: kColorLightOrange),
+      appBar: AppBar(title: Text(_modoHeaderTitle), backgroundColor: kColorLightblue),
       floatingActionButton: Column(
         mainAxisAlignment: MainAxisAlignment.end,
         children: [


### PR DESCRIPTION
Este PR incluye dos cambios con respecto a estilos:

- **Removido el tacho de eliminar del modal al abrir un marker.** Era un icono que no tenía comportamiento ni tests, como no sabemos si vamos a llegar a implementar esa feature lo retiré. De todas formas dejo acá el código retirado de MarkerIcon por si nos da el tiempo de implementarlo:

<pre>
            IconButton(
                key: ValueKey("DeleteButton"),
                icon: Icon(Icons.delete),
                color: Colors.red,
                onPressed: () {
                  //TODO BORRAR EL MARCADOR
                }),
</pre>

- **Cambio de colores de varias pantallas del naranja claro al celeste.** En algún momento se cambió el color de headers de pages y del drawer a un color naranja claro. Esta decisión no fue debatida lo suficiente e iba en contra de los mockups hechos. Como estamos cerca de la demo, lo vuelvo a cambiar al color original en casi todas las pantallas. 

Originalmente la app se planteó con un esquema/armonía de color complementaria y con las tonalidades celeste y naranja, el naranja usado como color de acción principal y el celeste como color secundario/de background. El color de acción se usa para guiar al usuario al realizar una acción, y generalmente se utilizan colores cálidos o que resaltan del resto de la vista. El cambiar el celeste por el naranja hace que el naranja deje de ser un color de acción en la aplicación, y no permite al usuario ver las acciones facilmente (inciar sesión, registrarse, publicar un Marker, etc). Además, el cambio no era consistente con los colores en los detalles de fondo de las pantallas de iniciar sesión y registrarse.

Donde sí es más posible realizar este cambio es en secciones de configuración críticas para el usuario (cambiar su username, su contraseña, etc), ya que usar el naranja como background es una buena señal al usuario de que no se encuentra en un lugar común en la aplicación y que tenga cuidado, por lo tanto dejé el fondo anaranjado que tenía.

Estos cambios de colores no impactan en ninguna funcionalidad ni ningún test.


